### PR TITLE
fix: remove late final from _geohash

### DIFF
--- a/lib/src/cluster_item.dart
+++ b/lib/src/cluster_item.dart
@@ -5,7 +5,7 @@ import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platf
 mixin ClusterItem {
   LatLng get location;
 
-  late final String? _geohash;
+  String? _geohash;
   String get geohash => _geohash ??=
       Geohash.encode(location, codeLength: ClusterManager.precision);
 }


### PR DESCRIPTION
The current version of dart does not support using ??= with a late final variable. Attempting to do this results in an initial read which triggers a LateInitializationError.